### PR TITLE
OpenGL library setup in Qt 5.5 or above version

### DIFF
--- a/example/example.pro
+++ b/example/example.pro
@@ -6,6 +6,9 @@ SOURCES += main.cpp
 
 RESOURCES += qml.qrc
 
+# Qt 5.5 https://forum.qt.io/topic/56353/qt-5-5-opengl-link-errors/2
+LIBS += -lopengl32 -lglu32
+
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH =
 

--- a/spineqmlplugin/spineqmlplugin.pro
+++ b/spineqmlplugin/spineqmlplugin.pro
@@ -49,3 +49,5 @@ RESOURCES += resource.qrc
 include(../example/deployment.pri)
 qtcAddDeployment()
 
+# Qt 5.5 https://forum.qt.io/topic/56353/qt-5-5-opengl-link-errors/2
+LIBS += -lopengl32 -lglu32


### PR DESCRIPTION
- OpenGL library setup in Qt 5.5 or above version
  - See https://forum.qt.io/topic/56353/qt-5-5-opengl-link-errors/2 for more information.
- Tested Environment
  - Qt 5.13.0
  - MingW 7.3.0 64bit